### PR TITLE
Fix for tokyogas update (maybe e-mail address was changed)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,6 @@ jobs:
         run: |
           stack config set system-ghc --global true
           stack config set install-ghc --global false
-          stack config set recommend-stack-upgrade false
       - name: Build
         run: stack build --fast
       - name: Test

--- a/client/gas/gmail.js
+++ b/client/gas/gmail.js
@@ -21,7 +21,10 @@ const getMessage = (thread) => {
 const getUnreadBillingMailsWith = (f) => {
   const alreadyReadLabel = "Kiirotori/TokyoGasAlreadyRead";
   const title = "【myTOKYOGAS】ご請求料金確定のお知らせ";
-  const q = ["from:members@tokyo-gas.co.jp has:nouserlabels", title].join(" ");
+  const q = [
+    "from:official-enews@mail.tokyo-gas.co.jp has:nouserlabels",
+    title,
+  ].join(" ");
   const url = "https://members.tokyo-gas.co.jp/services/mieru/total.html";
 
   const label = getLabel(alreadyReadLabel);


### PR DESCRIPTION
- https://members.tokyo-gas.co.jp/contents/public/about/renewal.html
- maybe the email address was changed: members@tokyo-gas.co.jp -> official-enews@mail.tokyo-gas.co.jp